### PR TITLE
Adds "install_requires" with required dependencies

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,0 @@
-braceexpand==0.1.2
-Click==7.0
-docker==3.7.0
-pyaml==19.4.1
-yamllint==1.17.0

--- a/setup.py
+++ b/setup.py
@@ -24,5 +24,7 @@ setuptools.setup(
         'braceexpand==0.1.2',
         'Click==7.0',
         'pyaml==19.4.1',
+        'docker==3.7.0',
+        'yamllint==1.17.0'
     ]
 )

--- a/setup.py
+++ b/setup.py
@@ -20,4 +20,9 @@ setuptools.setup(
     entry_points={
         'console_scripts': ['brick=brick.__main__:entrypoint']
     },
+    install_requires=[
+        'braceexpand==0.1.2',
+        'Click==7.0',
+        'pyaml==19.4.1',
+    ]
 )


### PR DESCRIPTION
If one currently installs via:
`pip3 install -U git+ssh://git@github.com/tmrowco/brick.git@master`
the dependencies are not automatically installed. Apparently its best practice to have entries in both `requirements.txt` (for dev purposes) and `install_requires` (for packaging) and not combine in one. 