### PR TITLE
Brick prune

### DIFF
--- a/brick/dockerlib.py
+++ b/brick/dockerlib.py
@@ -1,3 +1,4 @@
+import arrow
 import os
 import tempfile
 import subprocess
@@ -99,3 +100,19 @@ def docker_build(tags, dockerfile_contents, pass_ssh=False, no_cache=False, secr
             tag=version)
 
     return tags[-1]
+
+
+def docker_images_list(name, last_tagged_before=None):
+    return [
+        {
+            "id": x.attrs["Id"],
+            "tags": x.tags,
+            "size": x.attrs["Size"],
+            "lastTagTime": x.attrs["Metadata"]["LastTagTime"],
+        }
+        for x in docker_client.images.list(f"{name}_*")
+        if not last_tagged_before or arrow.get(x.attrs["Metadata"]["LastTagTime"]) < arrow.get(last_tagged_before)]
+
+
+def docker_image_delete(image_id, force=False):
+    docker_client.images.remove(image=image_id, noprune=False, force=force)

--- a/setup.py
+++ b/setup.py
@@ -21,6 +21,7 @@ setuptools.setup(
         'console_scripts': ['brick=brick.__main__:entrypoint']
     },
     install_requires=[
+        'arrow==0.12.1',
         'braceexpand==0.1.2',
         'Click==7.0',
         'pyaml==19.4.1',


### PR DESCRIPTION
Fixes #19 
- adds a `brick prune` command which removes images that are NOT tagged as master or latest, and that are more than 3 days old. Note that no-op builds update the tag date. This effectively means we delete builds from branches that are > 3 days old.
- also works recursively using `brick -r prune`
![image](https://user-images.githubusercontent.com/1655848/74717364-8dd9f200-5230-11ea-9551-cdaa41430118.png)

cc @robertahunt FYI