### PR TITLE
Updates logging for "prune" to tell about skipped images

### DIFF
--- a/brick/__main__.py
+++ b/brick/__main__.py
@@ -404,6 +404,7 @@ def prune(ctx, target):
         # then this must be a branch build,
         # and it can be considered for deletion
         if any([':master' in t or ':latest' in t for t in image["tags"]]):
+            logger.info(f'Skipping {target_rel_path}..')
             continue
         logger.info(f'Deleting {image["tags"][0]} ({round(image["size"] / 1024 / 1024)}M)..')
         docker_image_delete(image['id'], force=True)

--- a/brick/__main__.py
+++ b/brick/__main__.py
@@ -404,7 +404,7 @@ def prune(ctx, target):
         # then this must be a branch build,
         # and it can be considered for deletion
         if any([':master' in t or ':latest' in t for t in image["tags"]]):
-            logger.info(f'Skipping {target_rel_path}..')
+            logger.info(f'Skipping {image["tags"][0]}..')
             continue
         logger.info(f'Deleting {image["tags"][0]} ({round(image["size"] / 1024 / 1024)}M)..')
         docker_image_delete(image['id'], force=True)


### PR DESCRIPTION
Currently it only logs:
```
+ brick -r prune
2020-02-18 10:33:35,534 [INFO] Found 15 target(s)..
```
But maybe it would be nice to have some more info? Not sure if it makes sense, so feel free to close this if not :)

An alternative solution could also be to log a "No images deleted" or something similar.