### PR TITLE
Changes glob to avoid searching through node_modules

### DIFF
--- a/brick/__main__.py
+++ b/brick/__main__.py
@@ -20,6 +20,9 @@ from .logger import logger, handler
 
 docker_client = docker.from_env()
 
+# Folder exclude patterns separated by |. (e.g. 'node_modules|dist|whatever')
+GLOB_EXCLUDES = 'node_modules'
+
 # Discover git branch
 GIT_BRANCH = subprocess.check_output(
     "git branch --contains `git rev-parse HEAD` | "
@@ -128,7 +131,7 @@ def generate_dockerfile_contents(from_image,
 def check_recursive(ctx, target, fun):
     if ctx.parent.params.get('recursive'):
         start = time.perf_counter()
-        targets = [os.path.dirname(x) for x in sorted(wcmatch.WcMatch(f'{target}', 'BUILD.yaml', 'node_modules', flags=wcmatch.RECURSIVE).match())]
+        targets = [os.path.dirname(x) for x in sorted(wcmatch.WcMatch(f'{target}', 'BUILD.yaml', GLOB_EXCLUDES, flags=wcmatch.RECURSIVE).match())]
         logger.info(f'Found {len(targets)} target(s)..')
         for recursive_target in targets:
             # Note: the recursive parameter will not be passed

--- a/brick/__main__.py
+++ b/brick/__main__.py
@@ -1,17 +1,18 @@
 #!/usr/bin/env python3
 
-import glob
 import logging
 import tempfile
 import os
 import shutil
 import subprocess
 import sys
+import time
 
 import arrow
 import click
 import docker
 import yaml
+from wcmatch import wcmatch
 
 from .dockerlib import docker_run, docker_build, docker_images_list, docker_image_delete
 from .lib import expand_inputs, ROOT_PATH, intersecting_outputs
@@ -126,12 +127,15 @@ def generate_dockerfile_contents(from_image,
 
 def check_recursive(ctx, target, fun):
     if ctx.parent.params.get('recursive'):
-        targets = [os.path.dirname(x) for x in sorted(glob.glob(f'{target}/**/BUILD.yaml', recursive=True))]
+        start = time.perf_counter()
+        targets = [os.path.dirname(x) for x in sorted(wcmatch.WcMatch(f'{target}', 'BUILD.yaml', 'node_modules', flags=wcmatch.RECURSIVE).match())]
         logger.info(f'Found {len(targets)} target(s)..')
         for recursive_target in targets:
             # Note: the recursive parameter will not be passed
             # and thus the recursion will end here
             ctx.invoke(fun, target=recursive_target)
+        end = time.perf_counter()
+        logger.info(f'🌟 All targets finished in {round(end - start, 2)} seconds')
         return True
 
 

--- a/setup.py
+++ b/setup.py
@@ -26,6 +26,7 @@ setuptools.setup(
         'Click==7.0',
         'pyaml==19.4.1',
         'docker==3.7.0',
-        'yamllint==1.17.0'
+        'yamllint==1.17.0',
+        "wcmatch==6.0.1"
     ]
 )


### PR DESCRIPTION
Currently we're recursively searching through all folders for `BUILD.yaml` files. But that also means searching inside any/all node_modules folders, which I believe is not an intended effect - it slows it down and in my use case it takes ~5-10 seconds just for doing that.


Here's the responsible code:

https://github.com/tmrowco/brick/blob/cb84fceb3d4932622de9c23e210c95d032a76728/brick/__main__.py#L129


I tried looking around, but couldn't find a good way of doing what I wanted with the native `glob` package. 

I did however manage to get the intended result by using [wcmatch](https://facelessuser.github.io/wcmatch/wcmatch/):

```python
targets = [os.path.dirname(x) for x in sorted(wcmatch.WcMatch(f'{target}', 'BUILD.yaml', 'node_modules', flags=wcmatch.RECURSIVE).match())]
```


And here's the difference (on a limited sample of packages):

![Screenshot 2020-05-13 at 17 06 33](https://user-images.githubusercontent.com/3296643/81830248-20daad80-953c-11ea-8c10-f9ecaa55a3e2.png)
