### PR TITLE
Optimize performance (~4X faster build when images are up-to-date)

### DIFF
--- a/brick/__main__.py
+++ b/brick/__main__.py
@@ -15,7 +15,7 @@ import yaml
 from wcmatch import wcmatch
 
 from .dockerlib import docker_run, docker_build, docker_images_list, docker_image_delete
-from .lib import expand_inputs, ROOT_PATH, intersecting_outputs
+from .lib import get_config, expand_inputs, ROOT_PATH, intersecting_outputs
 from .logger import logger, handler
 
 docker_client = docker.from_env()
@@ -191,8 +191,7 @@ def prepare(ctx, target, skip_previous_steps):
 
     start_time = time.perf_counter()
     target_rel_path = os.path.relpath(target, start=ROOT_PATH)
-    with open(os.path.join(target, 'BUILD.yaml')) as f:
-        config = yaml.load(f, Loader=yaml.FullLoader)
+    config = get_config(target)
     steps = config['steps']
     name = get_name(target_rel_path)
 
@@ -234,8 +233,7 @@ def build(ctx, target, skip_previous_steps):
 
     start_time = time.perf_counter()
     target_rel_path = os.path.relpath(target, start=ROOT_PATH)
-    with open(os.path.join(target, 'BUILD.yaml')) as f:
-        config = yaml.load(f, Loader=yaml.FullLoader)
+    config = get_config(target)
     steps = config['steps']
     name = get_name(target_rel_path)
 
@@ -319,8 +317,7 @@ def test(ctx, target, skip_previous_steps):
 
     start_time = time.perf_counter()
     target_rel_path = os.path.relpath(target, start=ROOT_PATH)
-    with open(os.path.join(target, 'BUILD.yaml')) as f:
-        config = yaml.load(f, Loader=yaml.FullLoader)
+    config = get_config(target)
     steps = config['steps']
     name = get_name(target_rel_path)
 
@@ -360,8 +357,7 @@ def deploy(ctx, target, skip_previous_steps):
         return
 
     target_rel_path = os.path.relpath(target, start=ROOT_PATH)
-    with open(os.path.join(target, 'BUILD.yaml')) as f:
-        config = yaml.load(f, Loader=yaml.FullLoader)
+    config = get_config(target)
     steps = config['steps']
     name = get_name(target_rel_path)
 
@@ -436,8 +432,7 @@ def deploy(ctx, target, skip_previous_steps):
 @click.pass_context
 def develop(ctx, target):
     target_rel_path = os.path.relpath(target, start=ROOT_PATH)
-    with open(os.path.join(target, 'BUILD.yaml')) as f:
-        config = yaml.load(f, Loader=yaml.FullLoader)
+    config = get_config(target)
     steps = config['steps']
     name = get_name(target_rel_path)
 
@@ -482,8 +477,7 @@ def prune(ctx, target, skip_previous_steps):
 
     start_time = time.perf_counter()
     target_rel_path = os.path.relpath(target, start=ROOT_PATH)
-    with open(os.path.join(target, 'BUILD.yaml')) as f:
-        config = yaml.load(f, Loader=yaml.FullLoader)
+    config = get_config(target)
     steps = config['steps']
     name = get_name(target_rel_path)
     for image in docker_images_list(

--- a/brick/__main__.py
+++ b/brick/__main__.py
@@ -212,10 +212,6 @@ def prepare(ctx, target, skip_previous_steps):
     # Docker build
     logger.info(f'🔨 Preparing {target_rel_path}..')
     tags = compute_tags(name, 'prepare')
-    # TODO: When a PR is merged, `cache_from` will unfortunately not
-    # include the branch from which we're merging
-    # We're disabling it for now to see if Docker can handle caching on its own
-    # Ideally cache_from would not be needed? or could tage all tags matching {name}_prepare:* ??
     digest = docker_build(
         tags=tags,
         dockerfile_contents=dockerfile_contents)

--- a/brick/cache.py
+++ b/brick/cache.py
@@ -1,0 +1,46 @@
+
+import os
+import json
+from pathlib import Path
+from typing import Dict, Optional
+from typing_extensions import TypedDict  # available in Python 3.8+
+
+
+HOME_PATH = str(Path.home())
+CACHE_FILE = os.path.join(HOME_PATH, ".brick-cache.json")
+VERSION = 1
+
+CacheEntry = TypedDict("CacheEntry", {"dependency_hash": str})
+Cache = TypedDict("Cache", {"tags": Dict[str, CacheEntry], "version": int})
+
+
+def _get_cache() -> Cache:
+    try:
+        with open(CACHE_FILE, "r") as json_file:
+            current_cache: Cache = json.load(json_file)
+            return current_cache
+    except FileNotFoundError:
+        return Cache(tags={}, version=VERSION)
+
+
+class BuildCache:
+    '''
+    Cache for storing and retriving the hash of the latest build's inputs.
+    The cache stored in ~/.brick-cache.json
+    '''
+    @staticmethod
+    def get_hash(tag: str) -> Optional[str]:
+        cache_entry = _get_cache()["tags"].get(tag)
+        return cache_entry["dependency_hash"] if cache_entry else None
+
+    @staticmethod
+    def save_build(tag: str, dependency_hash: str) -> None:
+        # FIXME: we could store the output hash, so we would know if we need
+        # to extract it.
+        cache = _get_cache()
+        cache["tags"][tag] = CacheEntry(dependency_hash=dependency_hash)
+        with open(CACHE_FILE, "w+") as json_file:
+            json_file.write(json.dumps(cache, sort_keys=True, indent=2))
+
+
+__all__ = ["BuildCache"]

--- a/brick/dockerlib.py
+++ b/brick/dockerlib.py
@@ -2,6 +2,7 @@ import arrow
 import os
 import tempfile
 import subprocess
+from subprocess import PIPE
 import sys
 from typing import Tuple, List
 
@@ -23,7 +24,9 @@ def is_built_up_to_date(tag: str, dependency_paths: List[str]) -> bool:
     inspect_result = subprocess.run(
         f"docker inspect -f '{{{{ json .Metadata.LastTagTime }}}}' {tag}",
         shell=True,
-        capture_output=True)
+        check=False,
+        stdout=PIPE,
+        stderr=PIPE)
 
     image_exists = inspect_result and inspect_result.returncode == 0
 

--- a/brick/lib.py
+++ b/brick/lib.py
@@ -74,3 +74,19 @@ def intersecting_outputs(target, inputs):
                             break
     return sorted(matches)
 
+
+def get_config_path(target):
+    return os.path.join(target, 'BUILD.yaml')
+
+
+def get_relative_config_path(target):
+    return os.path.relpath(get_config_path(target), start=ROOT_PATH)
+
+
+def get_config(target):
+    try:
+        with open(get_config_path(target)) as f:
+            # TODO: we could be basic sanity checking here
+            return yaml.load(f, Loader=yaml.FullLoader)
+    except FileNotFoundError:
+        raise Exception(f'BUILD.yaml not found.')

--- a/brick/lib.py
+++ b/brick/lib.py
@@ -25,7 +25,7 @@ def expand_inputs(target, inputs):
             matches = glob.glob(os.path.join(ROOT_PATH, target, input_path), recursive=True)
             if not matches:
                 logger.debug(f'Could not find an match for {os.path.join(ROOT_PATH, target, input_path)}')
-                raise Exception(f'No matches found for input {input_path}')
+                raise Exception(f'No matches found for input {input_path} for target {target}')
             for g in matches:
                 # Paths should be relative to root
                 p = os.path.relpath(g, start=ROOT_PATH)

--- a/setup.py
+++ b/setup.py
@@ -26,6 +26,7 @@ setuptools.setup(
         'Click==7.0',
         'pyaml==19.4.1',
         'docker==3.7.0',
+        'typing-extensions==3.7.4.3',
         'yamllint==1.17.0',
         "wcmatch==6.0.1"
     ]


### PR DESCRIPTION
I've looked into Brick and wanted to figure out why building the tmrow repository was slower than expected. 

I got these timings locally when nothing changed and everything was already prepared and built:

    time brick -r prepare    : 48 seconds (same time if for example .npmrc was touched)
    time brick -r build      : 175 seconds

I would expect an almost instant prepare and build and time when the Docker images were up-to-date. 

It turns out that the overhead of running Buildit/Docker is rather slow for that many images – even though layers are cached. I tried to do some experiments with a plain Dockerfile and observed the same overhead.

I came up with two improvements some time ago... But now I managed to wrap it up into a PR. :) 

### UPDATE: Buildkit/Docker performance

The primary reasons for the performance issue with Buildkit on my machine are:
- general overhead in starting up Docker and running through each layer
- Slowest layers:  "resolve image config for" (0.4-1.2s), "[internal] load metadata for" (0.4s)



### Improvement 1: dependency change detection 

Idea: not running docker on `brick prepare` and `brick build` if input(s) and the BUILD.yaml file didn't change since the last image was tagged. I tried to think if this would work in all cases, and at least logically I cannot see why a build should be done if the inputs didn't change. Right? 🤔

UPDATE: originally I used the using file modified timestamps on input paths. But as file timestamps are not preserved in git, then CI wouldn't be able to cache anything as cloning the repository would update the modified timestamp. Instead we now hash all dependencies (inputs and BUILD.yaml file). The hashes are stored in a `~/.brick-cache.json` file.

When everything is prepared/built already:

    time brick -r prepare    : 1.5 seconds
    time brick -r build      : 66 seconds

So when everything is up-to-date: brick build time is 2.5X faster and prepare time is 32X faster. 🚀


### Improvement 2: output extraction using get_archive

The output extraction after a build is very slow. I noticed a comment around this to use `get_archive`. Doing so improves the performance a bit:

    time brick -r build      : 144 seconds (without improvement 1)


### Improvement 1 + 2:

When everything is already built:

    time brick -r build      : 46 seconds

So we end up with: brick build time is 4X faster and prepare time is still 24X faster. 🚀

But the build time should be instant when nothing changed, right? It turns out that collecting outputs is still very slow and is always done. 

When disabling any collecting of outputs:
    time brick -r build      : 5 seconds


### Conclusion

Of course these timing are made when everything is up-to-date. But as most PRs only touches a few images, then the performance improvement should be substantial on CI.

Next step could be to be more clever when doing output extraction using hashing. 🌤 But maybe that performance increase isn't worth the added complexities.


### TODO

- [x] Sanity check my assumption that prepare and build should not be done unless inputs or BUILD.yaml file changed
- [x] Performance test on CI (modified timestamp)
- [ ] Verify that we didn't break anything (mostly this would be stale builds, i.e. not building when we should) 
