### PR TITLE
Output extraction performance tweaks

### DIFF
--- a/brick/__main__.py
+++ b/brick/__main__.py
@@ -15,7 +15,7 @@ import yaml
 from wcmatch import wcmatch
 
 from .dockerlib import docker_run, docker_build, docker_images_list, docker_image_delete
-from .lib import expand_inputs, ROOT_PATH, intersecting_outputs
+from .lib import get_config, expand_inputs, ROOT_PATH, intersecting_outputs
 from .logger import logger, handler
 
 docker_client = docker.from_env()
@@ -191,8 +191,7 @@ def prepare(ctx, target, skip_previous_steps):
 
     start_time = time.perf_counter()
     target_rel_path = os.path.relpath(target, start=ROOT_PATH)
-    with open(os.path.join(target, 'BUILD.yaml')) as f:
-        config = yaml.load(f, Loader=yaml.FullLoader)
+    config = get_config(target)
     steps = config['steps']
     name = get_name(target_rel_path)
 
@@ -234,8 +233,7 @@ def build(ctx, target, skip_previous_steps):
 
     start_time = time.perf_counter()
     target_rel_path = os.path.relpath(target, start=ROOT_PATH)
-    with open(os.path.join(target, 'BUILD.yaml')) as f:
-        config = yaml.load(f, Loader=yaml.FullLoader)
+    config = get_config(target)
     steps = config['steps']
     name = get_name(target_rel_path)
 
@@ -319,8 +317,7 @@ def test(ctx, target, skip_previous_steps):
 
     start_time = time.perf_counter()
     target_rel_path = os.path.relpath(target, start=ROOT_PATH)
-    with open(os.path.join(target, 'BUILD.yaml')) as f:
-        config = yaml.load(f, Loader=yaml.FullLoader)
+    config = get_config(target)
     steps = config['steps']
     name = get_name(target_rel_path)
 
@@ -360,8 +357,7 @@ def deploy(ctx, target, skip_previous_steps):
         return
 
     target_rel_path = os.path.relpath(target, start=ROOT_PATH)
-    with open(os.path.join(target, 'BUILD.yaml')) as f:
-        config = yaml.load(f, Loader=yaml.FullLoader)
+    config = get_config(target)
     steps = config['steps']
     name = get_name(target_rel_path)
 
@@ -436,8 +432,7 @@ def deploy(ctx, target, skip_previous_steps):
 @click.pass_context
 def develop(ctx, target):
     target_rel_path = os.path.relpath(target, start=ROOT_PATH)
-    with open(os.path.join(target, 'BUILD.yaml')) as f:
-        config = yaml.load(f, Loader=yaml.FullLoader)
+    config = get_config(target)
     steps = config['steps']
     name = get_name(target_rel_path)
 
@@ -482,8 +477,7 @@ def prune(ctx, target, skip_previous_steps):
 
     start_time = time.perf_counter()
     target_rel_path = os.path.relpath(target, start=ROOT_PATH)
-    with open(os.path.join(target, 'BUILD.yaml')) as f:
-        config = yaml.load(f, Loader=yaml.FullLoader)
+    config = get_config(target)
     steps = config['steps']
     name = get_name(target_rel_path)
     for image in docker_images_list(

--- a/brick/__main__.py
+++ b/brick/__main__.py
@@ -212,10 +212,6 @@ def prepare(ctx, target, skip_previous_steps):
     # Docker build
     logger.info(f'🔨 Preparing {target_rel_path}..')
     tags = compute_tags(name, 'prepare')
-    # TODO: When a PR is merged, `cache_from` will unfortunately not
-    # include the branch from which we're merging
-    # We're disabling it for now to see if Docker can handle caching on its own
-    # Ideally cache_from would not be needed? or could tage all tags matching {name}_prepare:* ??
     digest = docker_build(
         tags=tags,
         dockerfile_contents=dockerfile_contents)

--- a/brick/lib.py
+++ b/brick/lib.py
@@ -74,3 +74,19 @@ def intersecting_outputs(target, inputs):
                             break
     return sorted(matches)
 
+
+def get_config_path(target):
+    return os.path.join(target, 'BUILD.yaml')
+
+
+def get_relative_config_path(target):
+    return os.path.relpath(get_config_path(target), start=ROOT_PATH)
+
+
+def get_config(target):
+    try:
+        with open(get_config_path(target)) as f:
+            # TODO: we could be basic sanity checking here
+            return yaml.load(f, Loader=yaml.FullLoader)
+    except FileNotFoundError:
+        raise Exception(f'BUILD.yaml not found.')

--- a/brick/lib.py
+++ b/brick/lib.py
@@ -25,7 +25,7 @@ def expand_inputs(target, inputs):
             matches = glob.glob(os.path.join(ROOT_PATH, target, input_path), recursive=True)
             if not matches:
                 logger.debug(f'Could not find an match for {os.path.join(ROOT_PATH, target, input_path)}')
-                raise Exception(f'No matches found for input {input_path}')
+                raise Exception(f'No matches found for input {input_path} for target {target}')
             for g in matches:
                 # Paths should be relative to root
                 p = os.path.relpath(g, start=ROOT_PATH)


### PR DESCRIPTION
(Pulled out from https://github.com/tmrowco/brick/pull/44). Fixes https://github.com/tmrowco/brick/issues/42. Closes https://github.com/tmrowco/brick/issues/2

The output extraction done during `brick build` is rather slow. I noticed [a comment](https://github.com/tmrowco/brick/blob/master/brick/__main__.py#L287-L288) in the code to use `get_archive` instead of mounting volumes, and doing so improves the performance _a bit._ 

A `brick -r build` on tmrow on my local machine when all images are already build: from 198-228 to 156-164 seconds (two measurements). 

I also did some other minor clean up while poking around and preparing for cache optimizations. 


### Future steps

If we simply remove all output extraction we get down to 122 seconds (compared to around ~210 seconds from above). This shows that there is still a lot to gain from optimizing the extraction. 