### PR TITLE
Changes to shasum package

### DIFF
--- a/brick/lib.py
+++ b/brick/lib.py
@@ -86,7 +86,7 @@ def compute_hash_from_paths(paths: List[str]) -> str:
     if not paths:
         raise ValueError("Expected input paths")
     stdout = subprocess.run(
-        f"find {' '.join(paths)} -type f -print0 | sort -z | xargs -0 sha1sum | sha1sum",
+        f"find {' '.join(paths)} -type f -print0 | sort -z | xargs -0 shasum | shasum",
         shell=True,
         check=True,
         stdout=subprocess.PIPE,


### PR DESCRIPTION
Changes from `sha1sum` which is not installed on MacOS to `shasum` which should be available on all unix-based systems.

`shasum` by default uses the `sha1` algorithm, so it should have no effect on anything AFAIK.

Fixes #49