### PR TITLE
Adds support for using external images as stage

### DIFF
--- a/brick/__main__.py
+++ b/brick/__main__.py
@@ -188,15 +188,15 @@ def cli(verbose, recursive, skip_previous_steps):
     else:
         handler.setLevel(logging.INFO)
 
-
 @cli.command()
 @click.argument('target', default='.')
 @click.pass_context
-def ls(ctx, target):
+def list(ctx, target):
     targets = [os.path.dirname(x) for x in sorted(wcmatch.WcMatch(f'{target}', 'BUILD.yaml', GLOB_EXCLUDES, flags=wcmatch.RECURSIVE).match())]
     logger.info(f'Found {len(targets)} target(s):')
     for target in targets:
         logger.info(target)
+
 
 
 @cli.command()

--- a/brick/__main__.py
+++ b/brick/__main__.py
@@ -100,8 +100,8 @@ def generate_dockerfile_contents(from_image,
                                       for x in inputs]) + '\n'
     # External images
     # https://docs.docker.com/develop/develop-images/multistage-build/#use-an-external-image-as-a-stage
-    if external_images:
-        dockerfile_contents += '\n'.join([f'COPY {x}\n' for x in external_images]) + '\n'
+    for k, v in (external_images or {}).items():
+        dockerfile_contents += f'COPY --from={v["tag"]} {v["src"]} {v["target"]}\n'
 
     dockerfile_contents += f"WORKDIR /home/{workdir or ''}\n"
     run_flags = []
@@ -284,7 +284,7 @@ def build(ctx, target, skip_previous_steps):
         commands=step.get('commands', []),
         entrypoint=step.get('entrypoint'),
         environment=step.get('environment', {}),
-        external_images=step.get('external_images', []),
+        external_images=step.get('external_images'),
         workdir=target_rel_path)
 
     # Docker build


### PR DESCRIPTION
Still not happy about the name, but `external_inputs` felt wrong since that's not really what it is :)

See documentation here: https://docs.docker.com/develop/develop-images/multistage-build/#use-an-external-image-as-a-stage

### Usage

```
  build:
    commands:
      - yarn lint
    entrypoint: exec /bin/berglas exec -- yarn start
    external_images:
      - --from=us-docker.pkg.dev/berglas/berglas/berglas:latest /bin/berglas /bin/berglas
    inputs:
      - index.js
      - src
      - ../shared
```
---

I also added a `brick list` command to make it easier to see what packages will be used. Let me know if it doesn't make sense or should have it's own PR.