### PR TITLE
Remove pyproject causing pip install issues

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -6,5 +6,9 @@
   "[python]": {
     "editor.formatOnSave": true,
     "editor.formatOnPaste": false
-  }
+  },
+  "python.formatting.blackArgs": [
+    "--target-version=py36",
+    "--line-length=100"
+  ]
 }

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,8 @@
 export PYTHONPATH=./brick
 VENV = .venv
 PY_FILES = $(shell find *.py brick -type f -name '*.py')
-BLACK_OPTIONS = brick setup.py
+# NOTE: we cannot currently use the pyproject.toml option as installation fails
+BLACK_OPTIONS = --target-version=py36 --line-length=100 brick setup.py
 all: $(VENV)
 
 
@@ -22,7 +23,7 @@ pylint: lint
 
 format: $(VENV) .format.made
 
-.format.made: $(PY_FILES) pyproject.toml
+.format.made: $(PY_FILES) Makefile
 	$(VENV)/bin/black $(BLACK_OPTIONS)
 	touch $@
 

--- a/brick/dockerlib.py
+++ b/brick/dockerlib.py
@@ -26,7 +26,7 @@ def docker_run(tag, command, volumes=None, ports=None, environment=None):
 
 
 def docker_build(
-    tags, dockerfile_contents, pass_ssh=False, no_cache=False, secrets=None, dependency_paths=None
+    tags, dockerfile_contents, pass_ssh=False, no_cache=False, secrets=None, dependency_paths=None,
 ) -> str:
     # pylint: disable=too-many-branches
     tag_to_return = tags[-1]  # Not sure why we return an argument the caller provided
@@ -68,7 +68,7 @@ def docker_build(
             basename = os.path.basename(src)
             tarfile = os.path.join(ROOT_PATH, f"{basename}.tar.gz")
             subprocess.run(
-                f"tar zc -C {src} --exclude='logs' . > {tarfile}", shell=True, check=True
+                f"tar zc -C {src} --exclude='logs' . > {tarfile}", shell=True, check=True,
             )
             cmd += f" --secret id={k},src={tarfile}"
         with subprocess.Popen(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,4 +1,0 @@
-[tool.black]
-line-length = 100
-target-version = ['py36']
-include = '\.pyi?$'


### PR DESCRIPTION
On some system the pip install step will fail if we have the pyproject.toml file (currently only used for configuring Black)... There is more context here: 
- https://github.com/psf/black/issues/683 
- https://github.com/pypa/pip/issues/6163
- https://github.com/pypa/setuptools/issues/1642

As Black only supports using pyproject for configuration, the best option seems to be duplicating the config and provide it as CLI arguments.

Another option is to force users to install with the "--no-use-pep517" (which also works, but isn't as nice for the end user).