### PR TITLE
Refactor Docker log output

### DIFF
--- a/brick/dockerlib.py
+++ b/brick/dockerlib.py
@@ -71,11 +71,12 @@ def docker_build(
                 f"tar zc -C {src} --exclude='logs' . > {tarfile}", shell=True, check=True,
             )
             cmd += f" --secret id={k},src={tarfile}"
+
         with subprocess.Popen(
             args=cmd,
             encoding="utf8",
             stdout=subprocess.PIPE,
-            stderr=subprocess.PIPE,
+            stderr=subprocess.STDOUT,
             shell=True,
             env=env,
             universal_newlines=True,
@@ -83,13 +84,14 @@ def docker_build(
         ) as p:
             logs = [cmd]
             logger.debug(cmd)
-            while True:
-                line = p.stderr.readline()
-                if line == "":
-                    break
-                log = line.rstrip("\n")
-                logs += [log]
-                logger.debug(log)
+
+            while p.poll() is None:
+                line = p.stdout.readline()
+                if line != "":
+                    line = line.rstrip("\n")
+                    logs.append(line)
+                    logger.debug(line)
+
             returncode = p.wait()
             if returncode:
                 _out, err = p.communicate()

--- a/brick/dockerlib.py
+++ b/brick/dockerlib.py
@@ -52,7 +52,7 @@ def docker_build(
         dockerfile.write(dockerfile_contents)
     try:
         iidfile = tempfile.mktemp()
-        cmd = f"docker build . --iidfile {iidfile} -f {dockerfile_path}"
+        cmd = f"docker build . --iidfile {iidfile} -f {dockerfile_path} --progress plain"
         env = {"DOCKER_BUILDKIT": "1"}
         if pass_ssh:
             cmd += " --ssh default"


### PR DESCRIPTION
While digging into the performance of Brick I _suspected_ that some log lines from Docker were being swallowed by Brick.

I'm not convinced this is the case anymore, but it made me refactor the docker log output. I do not believe this refactor have any changes on the output, but I verified that it logs all the lines from Docker. And I believe the code is a bit more robust.

### Changes:
- Do a [process poll](https://docs.python.org/3/library/subprocess.html#subprocess.Popen.poll) instead of waiting for an empty string (see https://www.saltycrane.com/blog/2009/10/how-capture-stdout-in-real-time-python/) 
- I also changed it to explicitly route the stderr to stdout to ensure we get all the logs.
- added progress plain (which is the default in a subprocess, but makes it easier to copy the command and run it manually)