### PR TITLE
Performance: caching on branches by promoting latest image

### DIFF
--- a/brick/__main__.py
+++ b/brick/__main__.py
@@ -28,11 +28,9 @@ docker_client = docker.from_env()
 # Folder exclude patterns separated by |. (e.g. 'node_modules|dist|whatever')
 GLOB_EXCLUDES = "node_modules"
 
-# Discover git branch
+# Git branch name with some replacement for making it Docker repository friendly
 GIT_BRANCH = subprocess.check_output(
-    "git branch --contains `git rev-parse HEAD` | "
-    "grep -v 'detached' | head -n 1 | sed 's/^* //' | "
-    r"sed 's/\//\-/' | sed 's/ *//g'",
+    "git rev-parse --abbrev-ref HEAD | " r"sed 's/\//\-/' | sed 's/ *//g'",
     shell=True,
     encoding="utf8",
 ).rstrip("\n")

--- a/brick/__main__.py
+++ b/brick/__main__.py
@@ -35,6 +35,12 @@ GIT_BRANCH = subprocess.check_output(
     encoding="utf8",
 ).rstrip("\n")
 
+MAIN_BRANCH = subprocess.check_output(
+    "git symbolic-ref refs/remotes/origin/HEAD | sed 's@^refs/remotes/origin/@@'",
+    shell=True,
+    encoding="utf8",
+).rstrip("\n")
+
 YARN_CACHE_LOCATION = "/usr/local/share/.cache/yarn"
 IMAGES_TO_YARN_CACHE_VERSION_DICT = {
     "node:8.11": "v1",
@@ -77,11 +83,17 @@ def compute_tags(name, step_name):
 
 
 def add_version_to_tag(name):
+    latest_tag = f"{name}:latest"
+    branch_tag = f"{name}:{GIT_BRANCH.replace('#', '').replace('/', '-')}"
+
     # Last tag should be the most specific
-    return [
-        f"{name}:latest",
-        f"{name}:{GIT_BRANCH.replace('#', '').replace('/', '-')}",
-    ]
+    if GIT_BRANCH == MAIN_BRANCH:
+        return [
+            latest_tag,
+            branch_tag,
+        ]
+
+    return [branch_tag]
 
 
 def get_name(target_rel_path):


### PR DESCRIPTION
Resolves https://github.com/tmrowco/brick/issues/55 

On CI this speeds up the build from 8 minute to 2 minutes when you create a new branch without any changes. 

### Changes

- Promote/reusing `latest` image matching the dependency hash
- Found a bug where the git branch conversion to docker tags didn't work (trailing numbers in branch names)
- Avoid tagging branches with "latest" (instead of two branches A and B both modifying the latest image, we now only have latest image on the main branch)
