### PR TITLE
Pass HOME and PATH env

### DIFF
--- a/brick/dockerlib.py
+++ b/brick/dockerlib.py
@@ -83,7 +83,7 @@ def docker_build(
     try:
         iidfile = tempfile.mktemp()
         cmd = f"docker build . --iidfile {iidfile} -f {dockerfile_path} --progress plain"
-        env = {"DOCKER_BUILDKIT": "1"}
+        env = {"DOCKER_BUILDKIT": "1", "HOME": os.environ['HOME'], "PATH": os.environ['PATH']}
         if pass_ssh:
             cmd += " --ssh default"
             env["SSH_AUTH_SOCK"] = os.environ["SSH_AUTH_SOCK"]

--- a/brick/dockerlib.py
+++ b/brick/dockerlib.py
@@ -83,7 +83,7 @@ def docker_build(
     try:
         iidfile = tempfile.mktemp()
         cmd = f"docker build . --iidfile {iidfile} -f {dockerfile_path} --progress plain"
-        env = {"DOCKER_BUILDKIT": "1", "HOME": os.environ['HOME'], "PATH": os.environ['PATH']}
+        env = {"DOCKER_BUILDKIT": "1", "HOME": os.environ["HOME"], "PATH": os.environ["PATH"]}
         if pass_ssh:
             cmd += " --ssh default"
             env["SSH_AUTH_SOCK"] = os.environ["SSH_AUTH_SOCK"]


### PR DESCRIPTION
With the latest update of docker/buildkit, the HOME and PATH variables need to be defined when the shell is started with docker build.
I therefore made an update to brick in order to pass those variables.