### PR TITLE
Keep latest tags for branches

### DIFF
--- a/brick/git.py
+++ b/brick/git.py
@@ -1,0 +1,14 @@
+import subprocess
+
+# Git branch name with some replacement for making it Docker repository friendly
+GIT_BRANCH = subprocess.check_output(
+    "git rev-parse --abbrev-ref HEAD | " r"sed 's/\//\-/' | sed 's/ *//g'",
+    shell=True,
+    encoding="utf8",
+).rstrip("\n")
+
+MAIN_BRANCH = subprocess.check_output(
+    "git symbolic-ref refs/remotes/origin/HEAD | sed 's@^refs/remotes/origin/@@'",
+    shell=True,
+    encoding="utf8",
+).rstrip("\n")


### PR DESCRIPTION
Resolves https://github.com/tmrowco/brick/issues/61

We recently introduced a [change](https://github.com/tmrowco/brick/pull/57/commits/80575aa701ab5ea2aa31f2198c08639c9cc077a1) to not not tag images on non-main branches with "latest". This avoids cache breaking as all branches will not all push the "latest" image – but it does break local development where the latest tag is used in Docker compose files.

I have a [workaround](https://github.com/tmrowco/brick/pull/63) if this indeed breaks the cache, when two branch builds tags the same repository with the `latest` tag and thereby breaks the cache.