### PR TITLE
Support environment variable in BUILD.yaml + having tag in build.tag

### DIFF
--- a/brick/lib.py
+++ b/brick/lib.py
@@ -109,6 +109,11 @@ def get_relative_config_path(target):
 
 
 def expand_brick_environment_variables(before_expansion: str) -> str:
+    """
+    Expands any environment variable that starts with BRICK_.
+    Support syntax: ${BRICK_FOO} and ${BRICK_FOO:-default}
+    """
+
     def replacer(match):
         groups = match.groupdict()
         key = groups["key"]

--- a/brick/lib.py
+++ b/brick/lib.py
@@ -117,7 +117,7 @@ def expand_brick_environment_variables(before_expansion: str) -> str:
         assert replacement, f"Did not find environment variable {key} or default value"
         return replacement
 
-    pattern = re.compile(r"[$]{(?P<key>BRICK_[A-Z_]*)(?:[:]-(?P<default>[A-z\d-]*))?}")
+    pattern = re.compile(r"[$]{(?P<key>BRICK_[A-Z\d_]*)(?:[:]-(?P<default>[A-z\d-]*))?}")
 
     after_expansion = pattern.sub(replacer, before_expansion)
 

--- a/brick/lib.py
+++ b/brick/lib.py
@@ -111,6 +111,8 @@ def get_config(target):
     try:
         with open(get_config_path(target)) as f:
             # TODO: we could be basic sanity checking here
-            return yaml.load(f, Loader=yaml.FullLoader)
+            data = os.path.expandvars(f.read())
+            print(data)
+            return yaml.load(data, Loader=yaml.FullLoader)
     except FileNotFoundError:
         raise Exception(f"BUILD.yaml not found.")

--- a/brick/lib.py
+++ b/brick/lib.py
@@ -112,7 +112,21 @@ def get_config(target):
         with open(get_config_path(target)) as f:
             # TODO: we could be basic sanity checking here
             data = os.path.expandvars(f.read())
-            print(data)
             return yaml.load(data, Loader=yaml.FullLoader)
     except FileNotFoundError:
         raise Exception(f"BUILD.yaml not found.")
+
+
+def get_build_repository_and_tag(steps):
+    """
+    Return None or a tuple (repository, tag) in case the build step defined a image name (build.tag)
+    """
+    build_image_name = steps.get("build", {}).get("tag")
+
+    if not build_image_name:
+        return None
+
+    if ":" in build_image_name:
+        return build_image_name.split(":")
+    else:
+        return [build_image_name, "latest"]

--- a/tests/test_lib.py
+++ b/tests/test_lib.py
@@ -1,5 +1,40 @@
 import pytest
 
+from brick.lib import expand_brick_environment_variables
 
-def test_hello_world():
-    assert 1 == 1  # py.test needs at least one test!
+
+def test_expand_brick_environment_variables(monkeypatch):
+    assert expand_brick_environment_variables("") == ""
+
+    # Supports default if BRICK_ variable is not found
+    assert (
+        expand_brick_environment_variables("tag: server:${BRICK_COMMIT_SHA:-latest}")
+        == "tag: server:latest"
+    )
+
+    # Should expand BRICK_ variables if found
+    monkeypatch.setenv("BRICK_COMMIT_SHA", "1234")
+    assert (
+        expand_brick_environment_variables("tag: server:${BRICK_COMMIT_SHA:-latest}")
+        == "tag: server:1234"
+    )
+
+    assert (
+        expand_brick_environment_variables("tag: server:${BRICK_COMMIT_SHA}") == "tag: server:1234"
+    )
+
+    # Should not expand non BRICK_ prefixed variables
+    assert (
+        expand_brick_environment_variables("tag: server:${COMMIT_SHA:-latest}")
+        == "tag: server:${COMMIT_SHA:-latest}"
+    )
+
+    # Raises exception if unsupported format is used
+    with pytest.raises(AssertionError) as excinfo:
+        expand_brick_environment_variables("tag: server:$BRICK_FOO")
+    assert "faulty BRICK_ environment" in str(excinfo.value)
+
+    # Raises exception if no default value is provided
+    with pytest.raises(AssertionError) as excinfo:
+        expand_brick_environment_variables("tag: server:${BRICK_FOO}")
+    assert "not find environment variable BRICK_FOO or default value" in str(excinfo.value)

--- a/tests/test_lib.py
+++ b/tests/test_lib.py
@@ -8,19 +8,19 @@ def test_expand_brick_environment_variables(monkeypatch):
 
     # Supports default if BRICK_ variable is not found
     assert (
-        expand_brick_environment_variables("tag: server:${BRICK_COMMIT_SHA:-latest}")
+        expand_brick_environment_variables("tag: server:${BRICK_COMMIT_SHA1:-latest}")
         == "tag: server:latest"
     )
 
     # Should expand BRICK_ variables if found
-    monkeypatch.setenv("BRICK_COMMIT_SHA", "1234")
+    monkeypatch.setenv("BRICK_COMMIT_SHA1", "1234")
     assert (
-        expand_brick_environment_variables("tag: server:${BRICK_COMMIT_SHA:-latest}")
+        expand_brick_environment_variables("tag: server:${BRICK_COMMIT_SHA1:-latest}")
         == "tag: server:1234"
     )
 
     assert (
-        expand_brick_environment_variables("tag: server:${BRICK_COMMIT_SHA}") == "tag: server:1234"
+        expand_brick_environment_variables("tag: server:${BRICK_COMMIT_SHA1}") == "tag: server:1234"
     )
 
     # Should not expand non BRICK_ prefixed variables

--- a/tests/test_lib.py
+++ b/tests/test_lib.py
@@ -1,6 +1,6 @@
 import pytest
 
-from brick.lib import expand_brick_environment_variables
+from brick.lib import expand_brick_environment_variables, get_build_repository_and_tag
 
 
 def test_expand_brick_environment_variables(monkeypatch):
@@ -38,3 +38,9 @@ def test_expand_brick_environment_variables(monkeypatch):
     with pytest.raises(AssertionError) as excinfo:
         expand_brick_environment_variables("tag: server:${BRICK_FOO}")
     assert "not find environment variable BRICK_FOO or default value" in str(excinfo.value)
+
+
+def test_get_build_repository_and_tag():
+    assert get_build_repository_and_tag({"build": {}}) is None
+    assert get_build_repository_and_tag({"build": {"tag": "foo:bar"}}) == ["foo", "bar"]
+    assert get_build_repository_and_tag({"build": {"tag": "foo"}}) == ["foo", "latest"]


### PR DESCRIPTION
This PR updates Brick with two new features:
- Support environment variable expansion in BUILD.yaml (limited to environment variables prefixed with `BRICK_`) 
- Support having Docker tags in `build.tag` (that currently just supports having a repository)

The primary use case is to inject commit SHA into build steps on CI. It means that images can be tagged with a unique value instead of always being tagged with `latest`.

### Example

```
steps:

  build:
    inputs:
      - metadata
    tag: eu.gcr.io/server:${BRICK_DRONE_COMMIT_SHA:-master}

  deploy:
    commands:
      - gcloud run deploy NAME --image eu.gcr.io/server:${BRICK_DRONE_COMMIT_SHA:-master}

```