### PR TITLE
Add additional dependency hash logging

### DIFF
--- a/brick/dockerlib.py
+++ b/brick/dockerlib.py
@@ -177,7 +177,7 @@ def get_image_names_with_dependency_hash(dependency_hash) -> List[str]:
         .strip()
     )
 
-    return images.split("\n")
+    return [s for s in images.split("\n") if s]
 
 
 def docker_image_delete(image_id, force=False):

--- a/brick/dockerlib.py
+++ b/brick/dockerlib.py
@@ -50,7 +50,9 @@ def docker_build(
     if dependency_hash:
         dockerfile_contents += f'\nLABEL brick.dependency_hash="{dependency_hash}"'
         images_matching_hash = get_image_names_with_dependency_hash(dependency_hash)
-        logger.debug(f"Found {len(images_matching_hash)} image(s) matching dependency hash")
+        logger.debug(
+            f"Found {len(images_matching_hash)} image(s) matching dependency hash ({images_matching_hash[0:2]}..)"
+        )
 
         images_are_build = set(tags).issubset(set(images_matching_hash))
         if images_are_build:


### PR DESCRIPTION
Add additional dependency hash logging.

While doing this I figure out that we do not filter out the empty string in the `get_image_names_with_dependency_hash`. This is not a problem, but it does look confusing and would sometimes log that `Found 1 image(s) matching dependency hash` was found (although no images was actually found).