### PR TITLE
Fix promotion not working when using a build tag

### DIFF
--- a/brick/dockerlib.py
+++ b/brick/dockerlib.py
@@ -55,7 +55,7 @@ def docker_build(
         dockerfile_contents += f'\nLABEL brick.dependency_hash="{dependency_hash}"'
         images_matching_hash = get_image_names_with_dependency_hash(dependency_hash)
         logger.debug(
-            f"Found {len(images_matching_hash)} image(s) matching dependency hash ({images_matching_hash[0:2]}..)"
+            f"Found {len(images_matching_hash)} image(s) matching dependency hash {dependency_hash} ({images_matching_hash[0:5]}..)"
         )
 
         images_are_build = set(tags).issubset(set(images_matching_hash))

--- a/brick/dockerlib.py
+++ b/brick/dockerlib.py
@@ -64,7 +64,7 @@ def docker_build(
             return tag_to_return
 
         # Investigate if we can promote an image instead of building it again
-        image_names = set([t.split(":")[0] for t in tags])
+        image_names = {t.split(":")[0] for t in tags}
         related_images_with_latest_tag = [
             image
             for image in images_matching_hash

--- a/brick/dockerlib.py
+++ b/brick/dockerlib.py
@@ -63,18 +63,16 @@ def docker_build(
             logger.debug(f"Skipping docker build as images are up to date with input dependencies")
             return tag_to_return
 
-        # Investigate if we can promote images instead of building them again
-        image_name = tag_to_return.split(":")[0]
+        # Investigate if we can promote an image instead of building it again
+        image_names = set([t.split(":")[0] for t in tags])
         related_images_with_latest_tag = [
             image
             for image in images_matching_hash
-            if image.split(":")[0] == image_name and image.endswith(":latest")
+            if image.split(":")[0] in image_names and image.endswith(":latest")
         ]
+
         if related_images_with_latest_tag:
             # Note that we could probably allow branch images to be used for promotion.
-            assert (
-                len(related_images_with_latest_tag) == 1
-            ), f"Expected one related image, but found {related_images_with_latest_tag}"
             image_with_latest_tag = related_images_with_latest_tag[0]
             logger.debug(f"Promoting image {image_with_latest_tag}")
             tag_image(image_name=image_with_latest_tag, tags=tags)

--- a/tests/test_brick.py
+++ b/tests/test_brick.py
@@ -194,9 +194,6 @@ def test_examples_node_build_2_on_master(caplog, monkeypatch) -> None:
     assert get_docker_images_built_from_debug_logs(debug_logs) == set([])  # nothing was built
 
 
-@pytest.mark.skip(
-    reason="promoting images actually doesn't work as intended when using a build tag"
-)
 def test_examples_node_build_3_on_feature_branch(caplog, monkeypatch) -> None:
     # NOTE: test depends on test_examples_node_build_1_on_master
     clean_up_output_folders()


### PR DESCRIPTION
Resolves #68

### Details on the issue 

The issue here is the confusing ordered list `tags` (should be named `imageNames` as it contains `repo:tag`). Previously when determining images we could promote we expected the repository in the `tags` to be the same. This is not the case when the user defines a `tag` in the build section of the configuration. 