### PR TITLE
Remove duplicate syntax directive for deploy

### DIFF
--- a/brick/__main__.py
+++ b/brick/__main__.py
@@ -470,7 +470,6 @@ def deploy(ctx, target, skip_previous_steps):
         return
 
     inputs = expand_inputs(target_rel_path, step.get("inputs", []))
-    dockerfile_contents = "# syntax = docker/dockerfile:experimental\n"
     inputs_from_build = None
     from_image = previous_tag
 
@@ -483,7 +482,7 @@ def deploy(ctx, target, skip_previous_steps):
             (previous_tag, os.path.join(target_rel_path, o)) for o in ["."] + outputs
         ]
 
-    dockerfile_contents += generate_dockerfile_contents(
+    dockerfile_contents = generate_dockerfile_contents(
         from_image=from_image,
         inputs=inputs,
         inputs_from_build=inputs_from_build,


### PR DESCRIPTION
Deployment on CI is currently failing with a cryptic "failed to create LLB definition: only one syntax parser directive can be used" error. 

This seems to be caused by having multiple `# syntax = docker/dockerfile:experimental` pragmas in the Dockerfile when deploying. I verified the solution locally.

Not sure why this surfaced now, but I assume something changed in the Docker backend/registry.