### PR TITLE
Show cache invalidation

### DIFF
--- a/brick/__main__.py
+++ b/brick/__main__.py
@@ -495,7 +495,7 @@ def deploy(ctx, target, skip_previous_steps):
     # Docker build
     logger.info(f"🚀 Deploying {target_rel_path}..")
 
-    docker_build, is_cached = docker_build(
+    _, is_cached = docker_build(
         tags=compute_tags(name, "deploy"),
         dockerfile_contents=dockerfile_contents,
         dependency_paths=None,  # always run deployment

--- a/brick/dockerlib.py
+++ b/brick/dockerlib.py
@@ -140,7 +140,7 @@ def docker_build(
                     # #9 DONE 0.0s
 
                     # Detect step id
-                    step_id_match = re.match("#(?P<id>\d+)", line)
+                    step_id_match = re.match(r"#(?P<id>\d+)", line)
                     if step_id_match:
                         step_id = step_id_match.group("id")
                     else:
@@ -151,7 +151,7 @@ def docker_build(
 
                     # Extra step extended info
                     step_match = re.match(
-                        "#(?P<id>\d+) \[.*(?P<number>\d+)/\d+\] (?P<command>.*)", line
+                        r"#(?P<id>\d+) \[.*(?P<number>\d+)/\d+\] (?P<command>.*)", line
                     )
                     if step_match:
                         assert step_id == step_match.group("id")

--- a/brick/dockerlib.py
+++ b/brick/dockerlib.py
@@ -1,4 +1,5 @@
 import os
+import re
 import tempfile
 import subprocess
 import sys
@@ -37,9 +38,10 @@ def tag_image(image_name: str, tags: List[str]):
 
 def docker_build(
     tags, dockerfile_contents, pass_ssh=False, no_cache=False, secrets=None, dependency_paths=None,
-) -> str:
+) -> (str, bool):
     # pylint: disable=too-many-branches
     tag_to_return = tags[-1]  # Not sure why we return an argument the caller provided
+    is_cached = True  # True by default
 
     # Optimization: Skip builds if the hash of dependencies (base image + inputs) did not change since
     # the last build.
@@ -61,7 +63,7 @@ def docker_build(
         images_are_build = set(tags).issubset(set(images_matching_hash))
         if images_are_build:
             logger.debug(f"Skipping docker build as images are up to date with input dependencies")
-            return tag_to_return
+            return tag_to_return, is_cached
 
         # Investigate if we can promote an image instead of building it again
         image_names = {t.split(":")[0] for t in tags}
@@ -76,7 +78,7 @@ def docker_build(
             image_with_latest_tag = related_images_with_latest_tag[0]
             logger.debug(f"Promoting image {image_with_latest_tag}")
             tag_image(image_name=image_with_latest_tag, tags=tags)
-            return tag_to_return
+            return tag_to_return, is_cached
 
     dockerfile_path = os.path.join(ROOT_PATH, ".brickdockerfile")
     if os.path.exists(dockerfile_path):
@@ -119,12 +121,54 @@ def docker_build(
             logs = [cmd]
             logger.debug(cmd)
 
+            # State machine keeping track of step
+            step_id = None
+            step_command = None
+            step_is_cacheable = None  # Some steps can't be cached
+
             while p.poll() is None:
                 line = p.stdout.readline()
                 if line != "":
                     line = line.rstrip("\n")
                     logs.append(line)
                     logger.debug(line)
+
+                    # A line is typically "#9 [3/6] COPY ...."
+                    # Followed by either
+                    # #9 CACHED
+                    # or
+                    # #9 DONE 0.0s
+
+                    # Detect step id
+                    step_id_match = re.match("#(?P<id>\d+)", line)
+                    if step_id_match:
+                        step_id = step_id_match.group("id")
+                    else:
+                        # Reset
+                        step_id = None
+                        step_command = None
+                        step_is_cacheable = None
+
+                    # Extra step extended info
+                    step_match = re.match(
+                        "#(?P<id>\d+) \[.*(?P<number>\d+)/\d+\] (?P<command>.*)", line
+                    )
+                    if step_match:
+                        assert step_id == step_match.group("id")
+                        step_command = step_match.group("command")
+                        # Steps of the form "#X [ Y/Z] ..." can be cached
+                        # However, "FROM" commands can't
+                        step_is_cacheable = not step_command.startswith("FROM ")
+                    cache_invalidated_match = line.startswith(f"#{step_id} DONE")
+                    if (
+                        line.startswith(f"#{step_id}")
+                        and step_is_cacheable
+                        and cache_invalidated_match
+                        and is_cached
+                    ):
+                        # Cache has been invalidated
+                        logger.info(f"Cache invalidated by {step_command}")
+                        is_cached = False
 
             returncode = p.wait()
             if returncode:
@@ -149,7 +193,7 @@ def docker_build(
 
     tag_image(image_name=digest, tags=tags)
 
-    return tag_to_return
+    return tag_to_return, is_cached
 
 
 def docker_images_list(name, last_tagged_before=None):

--- a/tests/test_brick.py
+++ b/tests/test_brick.py
@@ -141,9 +141,13 @@ def test_examples_node_build_1_on_master(monkeypatch, caplog) -> None:
 
     assert info_logs == [
         "🔨 Preparing brick_example_node..",
+        "Cache invalidated by COPY [brick_example_node/package.json, "
+        "/home/brick_example...",
         "💯 Preparation phase done!",
         "🔨 Building brick_example_node..",
-        "💯 Finished building brick_example_node!",
+        "Cache invalidated by COPY [brick_example_node/src, "
+        "/home/brick_example_node/src]",
+        "💯 Finished building brick_example_node (cached)!",
     ]
 
     expected_docker_images_built = {
@@ -176,9 +180,9 @@ def test_examples_node_build_2_on_master(caplog, monkeypatch) -> None:
 
     assert info_logs == [
         "🔨 Preparing brick_example_node..",
-        "💯 Preparation phase done!",
+        "💯 Preparation phase done (cached)!",
         "🔨 Building brick_example_node..",
-        "💯 Finished building brick_example_node!",
+        "💯 Finished building brick_example_node (cached)!",
     ]
 
     assert get_docker_images()[0] == {
@@ -207,9 +211,9 @@ def test_examples_node_build_3_on_feature_branch(caplog, monkeypatch) -> None:
 
     assert info_logs == [
         "🔨 Preparing brick_example_node..",
-        "💯 Preparation phase done!",
+        "💯 Preparation phase done (cached)!",
         "🔨 Building brick_example_node..",
-        "💯 Finished building brick_example_node!",
+        "💯 Finished building brick_example_node (cached)!",
     ]
 
     expected_docker_images_built = {
@@ -257,18 +261,18 @@ def test_workspace_build(monkeypatch, caplog) -> None:
     assert info_logs[:14] == [
         "Found 2 target(s)..",
         "🔨 Preparing brick_example_node..",
-        "💯 Preparation phase done!",
+        "💯 Preparation phase done (cached)!",
         "🔨 Building brick_example_node..",
-        "💯 Finished building brick_example_node!",
+        "💯 Finished building brick_example_node (cached)!",
         "🔨 Preparing brick_example_python..",
-        "💯 Preparation phase done!",
+        "💯 Preparation phase done (cached)!",
         "🔨 Building brick_example_python..",
         "➡️  Building dependency brick_example_node",
         "🔨 Preparing brick_example_node..",
-        "💯 Preparation phase done!",
+        "💯 Preparation phase done (cached)!",
         "🔨 Building brick_example_node..",
-        "💯 Finished building brick_example_node!",
-        "💯 Finished building brick_example_python!",
+        "💯 Finished building brick_example_node (cached)!",
+        "💯 Finished building brick_example_python (cached)!",
     ]
 
     assert info_logs[14].startswith("🌟 All targets finished in")
@@ -306,15 +310,16 @@ def test_workspace_test(monkeypatch, caplog) -> None:
         "Found 2 target(s)..",
         "Nothing to test",  # TODO: improve the log...
         "🔨 Preparing brick_example_python..",
-        "💯 Preparation phase done!",
+        "💯 Preparation phase done (cached)!",
         "🔨 Building brick_example_python..",
         "➡️  Building dependency brick_example_node",
         "🔨 Preparing brick_example_node..",
-        "💯 Preparation phase done!",
+        "💯 Preparation phase done (cached)!",
         "🔨 Building brick_example_node..",
-        "💯 Finished building brick_example_node!",
-        "💯 Finished building brick_example_python!",
+        "💯 Finished building brick_example_node (cached)!",
+        "💯 Finished building brick_example_python (cached)!",
         "🔍 Testing brick_example_python..",
+        "Cache invalidated by WORKDIR /home/brick_example_python",
         "✅ Tests passed!",
     ]
 

--- a/tests/test_brick.py
+++ b/tests/test_brick.py
@@ -258,7 +258,7 @@ def test_workspace_build(monkeypatch, caplog) -> None:
     debug_logs = get_log_messages(caplog, logging.DEBUG)
 
     # TODO: we are clearly re-building too much here:
-    assert info_logs[:15] == [
+    assert info_logs[:16] == [
         "Found 2 target(s)..",
         "🔨 Preparing brick_example_node..",
         "💯 Preparation phase done (cached)!",
@@ -273,10 +273,12 @@ def test_workspace_build(monkeypatch, caplog) -> None:
         "💯 Preparation phase done (cached)!",
         "🔨 Building brick_example_node..",
         "💯 Finished building brick_example_node (cached)!",
-        "💯 Finished building brick_example_python (cached)!",
+        "Cache invalidated by COPY [brick_example_python/src, "
+        "/home/brick_example_python/src]",
+        "💯 Finished building brick_example_python!",
     ]
 
-    assert info_logs[15].startswith("🌟 All targets finished in")
+    assert info_logs[16].startswith("🌟 All targets finished in")
 
     expected_docker_images_built = {
         "brick_example_node_prepare:latest",

--- a/tests/test_brick.py
+++ b/tests/test_brick.py
@@ -147,7 +147,7 @@ def test_examples_node_build_1_on_master(monkeypatch, caplog) -> None:
         "🔨 Building brick_example_node..",
         "Cache invalidated by COPY [brick_example_node/src, "
         "/home/brick_example_node/src]",
-        "💯 Finished building brick_example_node (cached)!",
+        "💯 Finished building brick_example_node!",
     ]
 
     expected_docker_images_built = {
@@ -258,14 +258,15 @@ def test_workspace_build(monkeypatch, caplog) -> None:
     debug_logs = get_log_messages(caplog, logging.DEBUG)
 
     # TODO: we are clearly re-building too much here:
-    assert info_logs[:14] == [
+    assert info_logs[:15] == [
         "Found 2 target(s)..",
         "🔨 Preparing brick_example_node..",
         "💯 Preparation phase done (cached)!",
         "🔨 Building brick_example_node..",
         "💯 Finished building brick_example_node (cached)!",
         "🔨 Preparing brick_example_python..",
-        "💯 Preparation phase done (cached)!",
+        "Cache invalidated by WORKDIR /home/brick_example_python",
+        "💯 Preparation phase done!",
         "🔨 Building brick_example_python..",
         "➡️  Building dependency brick_example_node",
         "🔨 Preparing brick_example_node..",
@@ -275,7 +276,7 @@ def test_workspace_build(monkeypatch, caplog) -> None:
         "💯 Finished building brick_example_python (cached)!",
     ]
 
-    assert info_logs[14].startswith("🌟 All targets finished in")
+    assert info_logs[15].startswith("🌟 All targets finished in")
 
     expected_docker_images_built = {
         "brick_example_node_prepare:latest",
@@ -306,7 +307,7 @@ def test_workspace_test(monkeypatch, caplog) -> None:
     info_logs = get_log_messages(caplog, logging.INFO)
     debug_logs = get_log_messages(caplog, logging.DEBUG)
 
-    assert info_logs[:13] == [
+    assert info_logs[:14] == [
         "Found 2 target(s)..",
         "Nothing to test",  # TODO: improve the log...
         "🔨 Preparing brick_example_python..",
@@ -323,7 +324,7 @@ def test_workspace_test(monkeypatch, caplog) -> None:
         "✅ Tests passed!",
     ]
 
-    assert info_logs[13].startswith("🌟 All targets finished in")
+    assert info_logs[14].startswith("🌟 All targets finished in")
 
     assert get_docker_images_built_from_debug_logs(debug_logs) == {
         "brick_example_python_test:master",


### PR DESCRIPTION
This PR showcases which step of the dockerfile invalidates the cache, as well as whether the whole build was cached or not.
```
src/electricitymap❯ brick build contrib/web
2021-01-02 14:49:00,650 [INFO] 🔨 Preparing src/electricitymap/contrib/web..
2021-01-02 14:49:02,782 [INFO] 💯 Preparation phase done (cached)!
2021-01-02 14:49:02,782 [INFO] 🔨 Building src/electricitymap/contrib/web..
2021-01-02 14:49:15,437 [INFO] Cache invalidated by COPY [src/electricitymap/contrib/web/topogen.sh, /home/src/electricitymap/contrib/web/topogen.sh]
2021-01-02 14:51:08,367 [INFO] 💯 Finished building src/electricitymap/contrib/web!
src/electricitymap❯ brick build contrib/web
2021-01-02 14:51:34,258 [INFO] 🔨 Preparing src/electricitymap/contrib/web..
2021-01-02 14:51:34,565 [INFO] 💯 Preparation phase done (cached)!
2021-01-02 14:51:34,566 [INFO] 🔨 Building src/electricitymap/contrib/web..
2021-01-02 14:51:43,775 [INFO] 💯 Finished building src/electricitymap/contrib/web (cached)!
```

Fixes https://github.com/tmrowco/brick/issues/43
FYI @madsnedergaard 