### PR TITLE
Add chown

### DIFF
--- a/brick/__main__.py
+++ b/brick/__main__.py
@@ -106,14 +106,21 @@ def generate_dockerfile_contents(
     dockerfile_contents = "# syntax = docker/dockerfile:experimental\n"
     dockerfile_contents += f"FROM {from_image}\n"
 
-    copy_flag_chown = f' --chown={chown}' if chown else ''
+    copy_flag_chown = f" --chown={chown}" if chown else ""
 
     if inputs_from_build:
         dockerfile_contents += (
-            "\n".join([f"COPY{copy_flag_chown} --from={x[0]} /home/{x[1]} /home/{x[1]}" for x in inputs_from_build])
+            "\n".join(
+                [
+                    f"COPY{copy_flag_chown} --from={x[0]} /home/{x[1]} /home/{x[1]}"
+                    for x in inputs_from_build
+                ]
+            )
             + "\n"
         )
-    dockerfile_contents += "\n".join([f'COPY{copy_flag_chown}  ["{x}", "/home/{x}"]' for x in inputs]) + "\n"
+    dockerfile_contents += (
+        "\n".join([f'COPY{copy_flag_chown}  ["{x}", "/home/{x}"]' for x in inputs]) + "\n"
+    )
     # External images
     # https://docs.docker.com/develop/develop-images/multistage-build/#use-an-external-image-as-a-stage
     for k, v in (external_images or {}).items():
@@ -262,7 +269,7 @@ def prepare(ctx, target, skip_previous_steps):
         commands=step.get("commands", []),
         environment=step.get("environment", {}),
         workdir=target_rel_path,
-        chown=step.get('chown'),
+        chown=step.get("chown"),
     )
 
     # Docker build
@@ -324,7 +331,7 @@ def build(ctx, target, skip_previous_steps):
         environment=step.get("environment", {}),
         external_images=step.get("external_images"),
         workdir=target_rel_path,
-        chown=step.get('chown'),
+        chown=step.get("chown"),
     )
 
     # Docker build
@@ -412,7 +419,7 @@ def test(ctx, target, skip_previous_steps):
         commands=step.get("commands", []),
         workdir=target_rel_path,
         environment=step.get("environment", {}),
-        chown=step.get('chown'),
+        chown=step.get("chown"),
     )
 
     # Docker build
@@ -497,7 +504,7 @@ def deploy(ctx, target, skip_previous_steps):
         workdir=target_rel_path,
         pass_ssh=step.get("pass_ssh", False),
         secrets=step.get("secrets"),
-        chown=step.get('chown'),
+        chown=step.get("chown"),
     )
 
     # Docker build

--- a/brick/__main__.py
+++ b/brick/__main__.py
@@ -124,7 +124,9 @@ def generate_dockerfile_contents(
     # External images
     # https://docs.docker.com/develop/develop-images/multistage-build/#use-an-external-image-as-a-stage
     for k, v in (external_images or {}).items():
-        dockerfile_contents += f'COPY {copy_flag_chown} --from={v["tag"]} {v["src"]} {v["target"]}\n'
+        dockerfile_contents += (
+            f'COPY {copy_flag_chown} --from={v["tag"]} {v["src"]} {v["target"]}\n'
+        )
 
     dockerfile_contents += f"WORKDIR /home/{workdir or ''}\n"
     run_flags = []

--- a/brick/__main__.py
+++ b/brick/__main__.py
@@ -106,25 +106,25 @@ def generate_dockerfile_contents(
     dockerfile_contents = "# syntax = docker/dockerfile:experimental\n"
     dockerfile_contents += f"FROM {from_image}\n"
 
-    copy_flag_chown = f" --chown={chown}" if chown else ""
+    copy_flag_chown = f"--chown={chown}" if chown else ""
 
     if inputs_from_build:
         dockerfile_contents += (
             "\n".join(
                 [
-                    f"COPY{copy_flag_chown} --from={x[0]} /home/{x[1]} /home/{x[1]}"
+                    f"COPY {copy_flag_chown} --from={x[0]} /home/{x[1]} /home/{x[1]}"
                     for x in inputs_from_build
                 ]
             )
             + "\n"
         )
     dockerfile_contents += (
-        "\n".join([f'COPY{copy_flag_chown}  ["{x}", "/home/{x}"]' for x in inputs]) + "\n"
+        "\n".join([f'COPY {copy_flag_chown} ["{x}", "/home/{x}"]' for x in inputs]) + "\n"
     )
     # External images
     # https://docs.docker.com/develop/develop-images/multistage-build/#use-an-external-image-as-a-stage
     for k, v in (external_images or {}).items():
-        dockerfile_contents += f'COPY{copy_flag_chown} --from={v["tag"]} {v["src"]} {v["target"]}\n'
+        dockerfile_contents += f'COPY {copy_flag_chown} --from={v["tag"]} {v["src"]} {v["target"]}\n'
 
     dockerfile_contents += f"WORKDIR /home/{workdir or ''}\n"
     run_flags = []

--- a/pylintrc
+++ b/pylintrc
@@ -570,7 +570,7 @@ valid-metaclass-classmethod-first-arg=cls
 [DESIGN]
 
 # Maximum number of arguments for function / method.
-max-args=10
+max-args=12
 
 # Maximum number of attributes for a class (see R0902).
 max-attributes=7

--- a/tests/test_brick.py
+++ b/tests/test_brick.py
@@ -273,7 +273,7 @@ def test_workspace_build(monkeypatch, caplog) -> None:
         "💯 Preparation phase done (cached)!",
         "🔨 Building brick_example_node..",
         "💯 Finished building brick_example_node (cached)!",
-        "Cache invalidated by COPY [brick_example_python/src, "
+        "Cache invalidated by COPY  [brick_example_python/src, "
         "/home/brick_example_python/src]",
         "💯 Finished building brick_example_python!",
     ]

--- a/tests/test_brick.py
+++ b/tests/test_brick.py
@@ -141,11 +141,11 @@ def test_examples_node_build_1_on_master(monkeypatch, caplog) -> None:
 
     assert info_logs == [
         "🔨 Preparing brick_example_node..",
-        "Cache invalidated by COPY [brick_example_node/package.json, "
+        "Cache invalidated by COPY  [brick_example_node/package.json, "
         "/home/brick_example...",
         "💯 Preparation phase done!",
         "🔨 Building brick_example_node..",
-        "Cache invalidated by COPY [brick_example_node/src, "
+        "Cache invalidated by COPY  [brick_example_node/src, "
         "/home/brick_example_node/src]",
         "💯 Finished building brick_example_node!",
     ]

--- a/tests/test_brick.py
+++ b/tests/test_brick.py
@@ -142,7 +142,7 @@ def test_examples_node_build_1_on_master(monkeypatch, caplog) -> None:
     assert info_logs == [
         "🔨 Preparing brick_example_node..",
         "Cache invalidated by COPY  [brick_example_node/package.json, "
-        "/home/brick_example...",
+        "/home/brick_exampl...",
         "💯 Preparation phase done!",
         "🔨 Building brick_example_node..",
         "Cache invalidated by COPY  [brick_example_node/src, "


### PR DESCRIPTION
This adds a new `chown` attribute to a configuration step.
It represents the user which will be used to copy input files.
This is required in cases where the base image uses a specific user. Docker by default copies files as `root`, and therefore we need to be able to change the user owning the files that will be copied.