### PR TITLE
Extend supported environment variables

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@ all: $(VENV)
 
 clean:
 	find brick -name "*.pyc" -delete
-	-rm -rf .*.made build dist *.egg-info coverage
+	-rm -rf .*.made build dist *.egg-info coverage .pytest_cache $(VENV)
 
 
 lint: $(VENV) .lint.made

--- a/brick/lib.py
+++ b/brick/lib.py
@@ -131,7 +131,7 @@ def expand_brick_environment_variables(before_expansion: str) -> str:
         assert replacement, f"Did not find environment variable {key} or default value"
         return replacement
 
-    pattern = re.compile(r"[$]{(?P<key>BRICK_[A-Z\d_]*)(?:[:]-(?P<default>[A-z\d-]*))?}")
+    pattern = re.compile(r"[$]{(?P<key>BRICK_[A-Z\d_]*)(?:[:]-(?P<default>[A-z\.\d-]*))?}")
 
     after_expansion = pattern.sub(replacer, before_expansion)
 

--- a/tests/test_brick.py
+++ b/tests/test_brick.py
@@ -141,12 +141,10 @@ def test_examples_node_build_1_on_master(monkeypatch, caplog) -> None:
 
     assert info_logs == [
         "🔨 Preparing brick_example_node..",
-        "Cache invalidated by COPY  [brick_example_node/package.json, "
-        "/home/brick_exampl...",
+        "Cache invalidated by COPY  [brick_example_node/package.json, /home/brick_exampl...",
         "💯 Preparation phase done!",
         "🔨 Building brick_example_node..",
-        "Cache invalidated by COPY  [brick_example_node/src, "
-        "/home/brick_example_node/src]",
+        "Cache invalidated by COPY  [brick_example_node/src, /home/brick_example_node/src]",
         "💯 Finished building brick_example_node!",
     ]
 
@@ -273,8 +271,7 @@ def test_workspace_build(monkeypatch, caplog) -> None:
         "💯 Preparation phase done (cached)!",
         "🔨 Building brick_example_node..",
         "💯 Finished building brick_example_node (cached)!",
-        "Cache invalidated by COPY  [brick_example_python/src, "
-        "/home/brick_example_python/src]",
+        "Cache invalidated by COPY  [brick_example_python/src, " "/home/brick_example_python/src]",
         "💯 Finished building brick_example_python!",
     ]
 

--- a/tests/test_lib.py
+++ b/tests/test_lib.py
@@ -12,6 +12,11 @@ def test_expand_brick_environment_variables(monkeypatch):
         == "tag: server:latest"
     )
 
+    assert (
+        expand_brick_environment_variables("${BRICK_DB_HOST:-host.docker.internal}")
+        == "host.docker.internal"
+    )
+
     # Should expand BRICK_ variables if found
     monkeypatch.setenv("BRICK_COMMIT_SHA1", "1234")
     assert (


### PR DESCRIPTION
The regular expression used for parsing the environment variables now supports dots.

Example: `${BRICK_DB_HOST:-host.docker.internal}`