### PR TITLE
Add --no-cache option for deploy command

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,0 +1,3 @@
+{
+  "recommendations": ["ms-python.vscode-pylance"]
+}

--- a/brick/__main__.py
+++ b/brick/__main__.py
@@ -439,8 +439,9 @@ def test(ctx, target, skip_previous_steps):
 @cli.command()
 @click.argument("target", default=".")
 @click.argument("skip_previous_steps", default=False)
+@click.option("--no-cache", default=False, is_flag=True, help="skip caching deployment")
 @click.pass_context
-def deploy(ctx, target, skip_previous_steps):
+def deploy(ctx, target, skip_previous_steps, no_cache):
     if check_recursive(ctx, target, deploy):
         return
 
@@ -518,6 +519,7 @@ def deploy(ctx, target, skip_previous_steps):
         dependency_paths=None,  # always run deployment
         pass_ssh=step.get("pass_ssh", False),
         secrets=step.get("secrets"),
+        no_cache=no_cache,
     )
     logger.info(f"💯 Deploy finished{' (cached)' if is_cached else ''}!")
 

--- a/brick/dockerlib.py
+++ b/brick/dockerlib.py
@@ -4,7 +4,7 @@ import tempfile
 import subprocess
 import sys
 
-from typing import List
+from typing import List, Tuple
 import docker
 import arrow
 
@@ -38,7 +38,7 @@ def tag_image(image_name: str, tags: List[str]):
 
 def docker_build(
     tags, dockerfile_contents, pass_ssh=False, no_cache=False, secrets=None, dependency_paths=None,
-) -> (str, bool):
+) -> Tuple[str, bool]:
     # pylint: disable=too-many-branches
     tag_to_return = tags[-1]  # Not sure why we return an argument the caller provided
     is_cached = True  # True by default


### PR DESCRIPTION
In some situations, the user might want to rerun a deploy command. Currently, this is not possible, as the deploy step is caching (i.e. using the Docker cache).

Use cases:
1) One use case is using `brick deploy` locally to run database migrations. As the database might be wiped, we should allow rerunning `brick deploy`.
2) A production deployment silently failed and we want to rerun deployment without changing any files

### Solution

This PR adds a `--no-cache` flag to the deploy command. I considered adding this to other commands, but as they should never require re-running (as they do not create any side-effects).