### PR TITLE
Brick develop now also mounts prepare steps

### DIFF
--- a/brick/__main__.py
+++ b/brick/__main__.py
@@ -534,8 +534,11 @@ def develop(ctx, target):
     digest = ctx.invoke(prepare, target=target)
 
     step = steps["develop"]
+    prepare_step = steps.get("prepare")
     build_step = steps["build"]
     inputs = expand_inputs(target_rel_path, build_step["inputs"])
+    if prepare_step:
+        inputs += expand_inputs(target_rel_path, prepare_step.get("inputs"))
     volumes = {}
     for host_path in inputs:
         volumes[os.path.abspath(os.path.join(ROOT_PATH, host_path))] = {


### PR DESCRIPTION
# Use-case: updating dependencies using only brick

Consider a BUILD.yaml like this:
```yaml
steps:

  prepare:
    image: python:3.6
    inputs:
      - pyproject.toml
      - poetry.lock
    commands:
      - pip install poetry==1.1.4
      - poetry config virtualenvs.create false
      - poetry install

  develop:
    command: bash

  build:
    inputs:
      - debugger
    commands:
      - PYTHONPATH=.. poetry run pylint -E debugger
```

If one wants to update some python dependencies, one could edit the `poetry.toml` file, and then run `brick develop` to get a shell inside the container, before running `poetry update` which will update the lockfile.
It's imperative that the inputs from the `prepare` step are added as volumes, in addition to any inputs from the `develop` and `build` steps. This PRs makes sure the `prepare` step inputs are also added as volumes.

This is helpful in cases where someone is not able to run poetry locally.