### PR TITLE
Stabilize Brick output extraction 

### DIFF
--- a/brick/__main__.py
+++ b/brick/__main__.py
@@ -358,7 +358,7 @@ def build(ctx, target, skip_previous_steps):
 
     # Gather output
     for output in step.get("outputs", []):
-        logger.debug(f"Collecting {os.path.join(target_rel_path, output)}..")
+        logger.debug(f"Collecting {os.path.join(target_rel_path, output)} from {digest}")
         # Make sure we check that outputs are in this folder,
         # as else the dependency system won't work
         if os.path.abspath(os.path.join(ROOT_PATH, target_rel_path)) not in os.path.abspath(

--- a/pylintrc
+++ b/pylintrc
@@ -579,7 +579,7 @@ max-attributes=7
 max-bool-expr=5
 
 # Maximum number of branch for function / method body.
-max-branches=12
+max-branches=15
 
 # Maximum number of locals for function / method body.
 max-locals=20


### PR DESCRIPTION
We now retry the Brick output extraction if it fails and add additional debug logging.