### PR TITLE
Make test run locally again

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@ export PYTHONPATH=./brick
 VENV = .venv
 PY_FILES = $(shell find brick tests -type f -name '*.py')
 # NOTE: we cannot currently use the pyproject.toml option as installation fails
-BLACK_OPTIONS = --target-version=py36 --line-length=100 brick setup.py
+BLACK_OPTIONS = --target-version=py36 --line-length=100 brick setup.py tests
 all: $(VENV)
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -12,4 +12,3 @@ def pytest_sessionstart():
     from brick.logger import logger, handler
 
     logger.removeHandler(handler)
-


### PR DESCRIPTION
The tests are not running locally. 

This seems to be a regression introduced in https://github.com/tmrowco/brick/pull/75, where the info log checks differ if images are cached. 

In order to get consistent log messages, we could docker prune the system (but that takes a while). Instead, I removed the log specific assertions – which isn't really a good way of testing anyways.