### PR TITLE
Fix brick develop for empty input

### DIFF
--- a/brick/__main__.py
+++ b/brick/__main__.py
@@ -545,9 +545,9 @@ def develop(ctx, target):
     step = steps["develop"]
     prepare_step = steps.get("prepare")
     build_step = steps["build"]
-    inputs = expand_inputs(target_rel_path, build_step["inputs"])
+    inputs = expand_inputs(target_rel_path, build_step.get("inputs", []))
     if prepare_step:
-        inputs += expand_inputs(target_rel_path, prepare_step.get("inputs"))
+        inputs += expand_inputs(target_rel_path, prepare_step.get("inputs", []))
     volumes = {}
     for host_path in inputs:
         volumes[os.path.abspath(os.path.join(ROOT_PATH, host_path))] = {


### PR DESCRIPTION
`brick develop` would fail in case the input key was not defined.