### PR TITLE
Reset entryppoint

### DIFF
--- a/brick/dockerlib.py
+++ b/brick/dockerlib.py
@@ -15,7 +15,7 @@ docker_client = docker.from_env()
 
 
 def docker_run(tag, command, volumes=None, ports=None, environment=None):
-    cmd = "docker run --rm -ti"
+    cmd = "docker run --rm -ti --entrypoint=\"\""
     if volumes:
         cmd += f' {" ".join([f"-v {os.path.abspath(v)}:/home/{os.path.relpath(v, ROOT_PATH)}" for v in volumes])}'
     if ports:

--- a/brick/dockerlib.py
+++ b/brick/dockerlib.py
@@ -15,7 +15,7 @@ docker_client = docker.from_env()
 
 
 def docker_run(tag, command, volumes=None, ports=None, environment=None):
-    cmd = "docker run --rm -ti --entrypoint=\"\""
+    cmd = 'docker run --rm -ti --entrypoint=""'
     if volumes:
         cmd += f' {" ".join([f"-v {os.path.abspath(v)}:/home/{os.path.relpath(v, ROOT_PATH)}" for v in volumes])}'
     if ports:


### PR DESCRIPTION
For some base images, the `entrypoint` is changed such that `docker run -ti <image> bash` doesn't work.
This prevents using `brick develop` with a custom shell command.
I've therefore made sure that `brick develop` resets the `entrypoint` when calling `docker run`