### PR TITLE
Fix skip

### DIFF
--- a/brick/__main__.py
+++ b/brick/__main__.py
@@ -294,7 +294,7 @@ def prepare(ctx, target, skip_previous_steps=None):
 @cli.command()
 @click.argument("target", default=".")
 @click.pass_context
-def build(ctx, target, skip_previous_steps):
+def build(ctx, target, skip_previous_steps=None):
     if check_recursive(ctx, target, build):
         return
 


### PR DESCRIPTION
The `--skip-previous-steps` was only working when invoked recursively using `brick -r skip_previous_steps`, but not when invoked without the `-r` flag.
This PR fixed it.

See inline comments.