### PR TITLE
Fix output extraction instabilities

### DIFF
--- a/brick/__main__.py
+++ b/brick/__main__.py
@@ -386,10 +386,9 @@ def build(ctx, target, skip_previous_steps=None):
                 os.remove(host_path)
 
         host_output_folder = os.path.abspath(os.path.join(host_path, "../"))
-        # The docker create command creates a writeable container layer over the
-        # specified image and prepares it for running the specified command.
         container_id = run_shell_command(f"docker create {digest}")
         run_shell_command(f"docker cp {container_id}:{container_path} {host_output_folder}")
+        run_shell_command(f"docker rm -v {container_id}")
 
     logger.info(f"💯 Finished building {target_rel_path}{' (cached)' if is_cached else ''}!")
     log_exec_time("build", target_rel_path, start_time)

--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,7 @@ setuptools.setup(
     install_requires=[
         "arrow==0.12.1",
         "braceexpand==0.1.2",
-        "Click==7.0",
+        "Click==7.1.2",
         "pyaml==19.4.1",
         "docker==3.7.0",
         "typing-extensions==3.7.4.3",


### PR DESCRIPTION
This should fix the flaky output extraction bug that has been haunting us for some time. 

**Updated:** Originally I thought this would also speed up the output extraction, which is fairly slow (when everything is built already). Turns out this method is slightly slower.

A performance test on our `projects` folder, shows that we go from 11.5 seconds to 13 seconds. We save 0.5 seconds if we do not clean up the container again...

Ref: https://github.com/tmrowco/electricitymap/issues/137


### Background

I found a CI job where it consistently failed, so I logged into the build server and tried the docker libs commands in an interpreter:

`container = docker_client.containers.run(image='projects_co2signal-docs:ks-update-view', remove=True, detach=True)`
--> boot up a new container

`container.get_archive('/home/projects/co2signal-docs/build')`
--> fails to get the archive from the container as the container is not found (the container that was just started)

So I conclude that the bug is actually part of the docker python lib (https://pypi.org/project/docker/) that we are using.

One nice thing about doing this directly using docker is the speed! 
