### PR TITLE
Speed-ups (shasum + poetry install caching)

### DIFF
--- a/brick/__main__.py
+++ b/brick/__main__.py
@@ -4,7 +4,6 @@ import logging
 import os
 import shutil
 import time
-import subprocess
 
 import arrow
 import click
@@ -27,6 +26,7 @@ from .lib import (
 )
 from .git import GIT_BRANCH
 from .logger import logger, handler
+from .shell import run_shell_command
 
 docker_client = docker.from_env()
 
@@ -44,10 +44,6 @@ IMAGES_TO_YARN_CACHE_VERSION_DICT = {
     "node:10.19.0-alpine": "v6",
     "node:12.13.1": "v6",
 }
-
-
-def run_shell_command(cmd: str, check=True):
-    return subprocess.check_output(cmd, shell=True, encoding="utf8",).rstrip("\n")
 
 
 def is_yarn_install_command(cmd):

--- a/brick/__main__.py
+++ b/brick/__main__.py
@@ -45,9 +45,15 @@ IMAGES_TO_YARN_CACHE_VERSION_DICT = {
     "node:12.13.1": "v6",
 }
 
+POETRY_CACHE_LOCATION = "/root/.cache/pypoetry"
+
 
 def is_yarn_install_command(cmd):
     return cmd.startswith("yarn") or cmd.startswith("yarn install")
+
+
+def is_poetry_install_command(cmd):
+    return cmd.startswith("poetry install")
 
 
 timings = []
@@ -143,6 +149,9 @@ def generate_dockerfile_contents(
             location = f"{YARN_CACHE_LOCATION}/{cache_version}"
             logger.debug(f"Using yarn cache located at {location}")
             run_flags += [f"--mount=type=cache,target={location}"]
+        if is_poetry_install_command(cmd):
+            logger.debug(f"Using poetry cache located at {POETRY_CACHE_LOCATION}")
+            run_flags += [f"--mount=type=cache,target={POETRY_CACHE_LOCATION}"]
         if (secrets or {}).items():
             # Wrap the run command with a tar command
             # to untar and cleanup after us

--- a/brick/__main__.py
+++ b/brick/__main__.py
@@ -47,11 +47,7 @@ IMAGES_TO_YARN_CACHE_VERSION_DICT = {
 
 
 def is_yarn_install_command(cmd):
-    install_commands = ["yarn", "yarn install"]
-    # Strip flags and trim the string
-    split = cmd.split("--")
-    clean_command = split[0].strip()
-    return clean_command in install_commands
+    return cmd.startswith("yarn") or cmd.startswith("yarn install")
 
 
 timings = []

--- a/brick/lib.py
+++ b/brick/lib.py
@@ -98,10 +98,17 @@ def compute_hash_from_paths(paths: List[str]) -> str:
     if not paths:
         raise ValueError("Expected input paths")
 
+    t_start = time.time()
     sha1_command = get_sha1_command()
     cmd = f"find {' '.join(paths)} -type f -print0 | sort -z | xargs -0 {sha1_command} | {sha1_command}"
     sha1_sum: str = run_shell_command(cmd=cmd, cwd=ROOT_PATH).split(" ")[0].strip()
     assert len(sha1_sum) == 40, "expected sha1sum of length 40"
+
+    # Wasting more than a few seconds hashing usually means that the input dependencies
+    # should be tweaked.
+    hashing_time = time.time() - t_start
+    if hashing_time > 3:
+        logger.info(f'😴 Observed slow hashing ({hashing_time:.1f}s) for command "{cmd}"')
 
     return sha1_sum
 

--- a/brick/shell.py
+++ b/brick/shell.py
@@ -10,7 +10,7 @@ def run_shell_command(cmd: str, cwd: str = None) -> str:
 
 
 def get_sha1_command() -> str:
-    """Returns the sha1sum command support by the system"""
+    """Returns the fastest sha1sum command supported by the system"""
     # pylint: disable=global-statement
     global _sha1_command
     if not _sha1_command:

--- a/brick/shell.py
+++ b/brick/shell.py
@@ -1,0 +1,22 @@
+import subprocess
+
+from .logger import logger
+
+_sha1_command = None
+
+
+def run_shell_command(cmd: str, cwd: str = None) -> str:
+    return subprocess.check_output(cmd, shell=True, encoding="utf8", cwd=cwd).rstrip("\n")
+
+
+def get_sha1_command() -> str:
+    """Returns the sha1sum command support by the system"""
+    global _sha1_command
+    if not _sha1_command:
+        try:
+            run_shell_command("which sha1sum")
+            _sha1_command = "sha1sum"
+        except subprocess.CalledProcessError:
+            logger.info("sha1sum not found on this system (performance will be slightly degraded)")
+            _sha1_command = "shasum"
+    return _sha1_command

--- a/brick/shell.py
+++ b/brick/shell.py
@@ -11,6 +11,7 @@ def run_shell_command(cmd: str, cwd: str = None) -> str:
 
 def get_sha1_command() -> str:
     """Returns the sha1sum command support by the system"""
+    # pylint: disable=global-statement
     global _sha1_command
     if not _sha1_command:
         try:


### PR DESCRIPTION
A few speed up improvements:
- use the fastest available shasum command, which produces the same output. This yields a 30% speedup (context: https://github.com/tmrowco/brick/pull/50)
- poetry install caching similar to yarn install caching. Install time is reduced by 50% for a library 

We now also logs a message if hashing the input dependencies takes too long. Ideally, it should take < 1 second, but I identified some cases where we wasted ~20 seconds hashing as the input dependencies were too relaxed (e.g. hashing the entire contrib folder!)

Closes  #86 