### PR TITLE
Cache tests and deploy using dependency hash

### DIFF
--- a/brick/__main__.py
+++ b/brick/__main__.py
@@ -500,7 +500,7 @@ def deploy(ctx, target, no_cache, skip_previous_steps=None):
         return
 
     inputs = expand_inputs(target_rel_path, step.get("inputs", []))
-    inputs_from_build = None
+    inputs_from_build = []
     from_image = previous_tag
 
     if "image" in step:
@@ -511,6 +511,8 @@ def deploy(ctx, target, no_cache, skip_previous_steps=None):
         inputs_from_build = [
             (previous_tag, os.path.join(target_rel_path, o)) for o in ["."] + outputs
         ]
+
+    dependency_paths = inputs + [get_relative_config_path(target)] + inputs_from_build
 
     dockerfile_contents = generate_dockerfile_contents(
         from_image=from_image,
@@ -529,7 +531,7 @@ def deploy(ctx, target, no_cache, skip_previous_steps=None):
     _, is_cached = docker_build(
         tags=compute_tags(name, "deploy"),
         dockerfile_contents=dockerfile_contents,
-        dependency_paths=None,  # always run deployment
+        dependency_paths=dependency_paths,
         pass_ssh=step.get("pass_ssh", False),
         secrets=step.get("secrets"),
         no_cache=no_cache,

--- a/brick/__main__.py
+++ b/brick/__main__.py
@@ -424,6 +424,7 @@ def test(ctx, target, skip_previous_steps=None):
 
     step = steps["test"]
     inputs = expand_inputs(target_rel_path, step.get("inputs", []))
+    dependency_paths = inputs + [get_relative_config_path(target)]
     dockerfile_contents = generate_dockerfile_contents(
         from_image=build_tag,
         inputs=inputs,
@@ -437,7 +438,7 @@ def test(ctx, target, skip_previous_steps=None):
     logger.info(f"🔍 Testing {target_rel_path}..")
     digest, is_cached = docker_build(
         tags=compute_tags(name, "test"),
-        dependency_paths=None,  # always run tests
+        dependency_paths=dependency_paths,
         dockerfile_contents=dockerfile_contents,
     )
     logger.info(f"✅ Tests passed{' (cached)' if is_cached else ''}!")


### PR DESCRIPTION
When implementing the [dependency hash feature](https://github.com/tmrowco/brick/pull/46), I skipped using this feature for tests and deploys. After learning more about the internals of Brick, I now think it makes sense to also leverage the dependency hashing of inputs to skip running a docker build for tests and deploys.

On my machine it speeds up `brick test` a lot.

I added two FIXMEs in the code that are not related to this change.