### PR TITLE
Skip dependency hashing for deploys (for now)

### DIFF
--- a/brick/__main__.py
+++ b/brick/__main__.py
@@ -500,7 +500,7 @@ def deploy(ctx, target, no_cache, skip_previous_steps=None):
         return
 
     inputs = expand_inputs(target_rel_path, step.get("inputs", []))
-    inputs_from_build = []
+    inputs_from_build = None
     from_image = previous_tag
 
     if "image" in step:
@@ -511,8 +511,6 @@ def deploy(ctx, target, no_cache, skip_previous_steps=None):
         inputs_from_build = [
             (previous_tag, os.path.join(target_rel_path, o)) for o in ["."] + outputs
         ]
-
-    dependency_paths = inputs + [get_relative_config_path(target)] + inputs_from_build
 
     dockerfile_contents = generate_dockerfile_contents(
         from_image=from_image,
@@ -531,7 +529,7 @@ def deploy(ctx, target, no_cache, skip_previous_steps=None):
     _, is_cached = docker_build(
         tags=compute_tags(name, "deploy"),
         dockerfile_contents=dockerfile_contents,
-        dependency_paths=dependency_paths,
+        dependency_paths=None,  # TODO: we could use inputs + [get_relative_config_path(target)] + previous steps if using another image
         pass_ssh=step.get("pass_ssh", False),
         secrets=step.get("secrets"),
         no_cache=no_cache,

--- a/brick/lib.py
+++ b/brick/lib.py
@@ -98,6 +98,9 @@ def compute_hash_from_paths(paths: List[str]) -> str:
     if not paths:
         raise ValueError("Expected input paths")
 
+    if not isinstance(paths, list):
+        raise ValueError(f"Expected input paths as a list, got {type(paths)}")
+
     t_start = time.time()
     sha1_command = get_sha1_command()
     cmd = f"find {' '.join(paths)} -type f -print0 | sort -z | xargs -0 {sha1_command} | {sha1_command}"


### PR DESCRIPTION
This revert the dependency hashing for deploys (https://github.com/tmrowco/brick/pull/92/files), but keeps the hashing for `brick test`. 

We could do dependency hashing for deploys, but the custom image complicates things a bit...