### PR TITLE
Remove promotion/re-tagging feature

### DIFF
--- a/brick/__main__.py
+++ b/brick/__main__.py
@@ -580,9 +580,6 @@ def develop(ctx, target, skip_previous_steps=None):
     logger.info(f"🔨 Developing {target_rel_path}..")
     docker_run(tag=digest, command=command, volumes=volumes, ports=ports, environment=environment)
 
-    logger.info(f"👋 Finished developing {target_rel_path}")
-    return digest
-
 
 @cli.command()
 @click.argument("target", default=".")

--- a/brick/dockerlib.py
+++ b/brick/dockerlib.py
@@ -70,20 +70,8 @@ def docker_build(
             logger.debug(f"Skipping docker build as images are up to date with input dependencies")
             return tag_to_return, is_cached
 
-        # Investigate if we can promote an image instead of building it again
-        image_names = {t.split(":")[0] for t in tags}
-        related_images_with_latest_tag = [
-            image
-            for image in images_matching_hash
-            if image.split(":")[0] in image_names and image.endswith(":latest")
-        ]
-
-        if related_images_with_latest_tag:
-            # Note that we could probably allow branch images to be used for promotion.
-            image_with_latest_tag = related_images_with_latest_tag[0]
-            logger.debug(f"Promoting image {image_with_latest_tag}")
-            tag_image(image_name=image_with_latest_tag, tags=tags)
-            return tag_to_return, is_cached
+        # NOTE: Further optimization: promoting/re-tagging an image that matches the hash is possible,
+        # but the image will lose the original tag (which will cause a slowdown for other builds).
 
     dockerfile_path = os.path.join(ROOT_PATH, ".brickdockerfile")
     if os.path.exists(dockerfile_path):

--- a/tests/test_brick.py
+++ b/tests/test_brick.py
@@ -206,8 +206,6 @@ def test_examples_node_build_3_on_feature_branch(caplog, monkeypatch) -> None:
     assert (
         not "Skipping docker build as images are up to date with input dependencies" in debug_logs
     )
-    assert "Promoting image brick_example_node_prepare:latest" in debug_logs
-    assert "Promoting image brick_example_node_build:latest" in debug_logs
 
     assert get_docker_images_built_from_debug_logs(debug_logs) == expected_docker_images_built
 


### PR DESCRIPTION
The promoting of images (re-tagging images matching a hash) was introduced in https://github.com/tmrowco/brick/pull/57. Back then it showed an improvement for first build on a branch from 8 minutes to 2 minutes.

But an unforeseen side-effect it that promoting an image steals the `latest` tag. This means that master builds needs cannot reuse images that matches the hash.

I suggest we either:
- try out removing the promotion of images feature (this PR)
- or we do not use the `latest` tag, but a random tag matching the dependency hash. It would mean that branch builds might steal from each other instead (but as we have a lot of tags it should be fine).

