### PR TITLE
Allow branch images to be used for promotion

### DIFF
--- a/tests/test_brick.py
+++ b/tests/test_brick.py
@@ -212,7 +212,10 @@ def test_examples_node_build_3_on_feature_branch(caplog, monkeypatch) -> None:
     ]
 
     assert "Promoting image brick_example_node_prepare" in promote_logs_without_tag
-    assert "Promoting image brick_example_node_build" in promote_logs_without_tag
+    assert (
+        "Promoting image brick_example_node_build" in promote_logs_without_tag
+        or "Promoting image brick_example_node_prod" in promote_logs_without_tag
+    )  # Depending on which image it picks
 
     assert get_docker_images_built_from_debug_logs(debug_logs) == expected_docker_images_built
 

--- a/tests/test_brick.py
+++ b/tests/test_brick.py
@@ -206,8 +206,8 @@ def test_examples_node_build_3_on_feature_branch(caplog, monkeypatch) -> None:
     assert (
         not "Skipping docker build as images are up to date with input dependencies" in debug_logs
     )
-    assert "Promoting image brick_example_node_prepare:latest" in debug_logs
-    assert "Promoting image brick_example_node_build:latest" in debug_logs
+    assert "Promoting image brick_example_node_prepare" in debug_logs
+    assert "Promoting image brick_example_node_build" in debug_logs
 
     assert get_docker_images_built_from_debug_logs(debug_logs) == expected_docker_images_built
 

--- a/tests/test_brick.py
+++ b/tests/test_brick.py
@@ -206,8 +206,13 @@ def test_examples_node_build_3_on_feature_branch(caplog, monkeypatch) -> None:
     assert (
         not "Skipping docker build as images are up to date with input dependencies" in debug_logs
     )
-    assert "Promoting image brick_example_node_prepare" in debug_logs
-    assert "Promoting image brick_example_node_build" in debug_logs
+
+    promote_logs_without_tag = [
+        l.split(":")[0] for l in debug_logs if l.startswith("Promoting image")
+    ]
+
+    assert "Promoting image brick_example_node_prepare" in promote_logs_without_tag
+    assert "Promoting image brick_example_node_build" in promote_logs_without_tag
 
     assert get_docker_images_built_from_debug_logs(debug_logs) == expected_docker_images_built
 


### PR DESCRIPTION
Ref: https://github.com/tmrowco/electricitymap/issues/943

Currently we only promote images matching the dependency hash that has the `latest` tag. But I haven't found a good reason for not utilizing the fact that images are mostly build on branches.

I did some investigation in our CI logs and I see that we often find images matching the dependency hash, but we are not using them as they do not have the `latest` tag, but a branch tag.

I think this should speed everything up a lot. 🤞