### PR TITLE
Improve Brick logging output

### DIFF
--- a/brick/dockerlib.py
+++ b/brick/dockerlib.py
@@ -178,6 +178,7 @@ def docker_build(
                 _out, err = p.communicate()
                 logger.error("\n".join(logs))
                 logger.error(err)
+                logger.error(f"Failed building docker images for: {tags}")
                 sys.exit(returncode)
             os.remove(dockerfile_path)
     except (KeyboardInterrupt, SystemExit):


### PR DESCRIPTION
Here we are iterating a bit on the logging output produced by Brick:
- prefix with target name to make scanning it easier
- remove 💯 for completion results
- move some logs to debug logs (no tests and no builds)
- add final brick failure message including the tag (to make figuring out what target failed)

### Before
<img width="1496" alt="Screenshot 2021-09-20 at 12 58 12" src="https://user-images.githubusercontent.com/1260305/133992268-a0af7763-0ad7-40e2-8335-0d79f354a59d.png">

### After
<img width="1496" alt="Screenshot 2021-09-20 at 12 57 55" src="https://user-images.githubusercontent.com/1260305/133992261-1f67a044-a660-425f-8eda-5a7599e65c58.png">
